### PR TITLE
Automate adding a license header to every file

### DIFF
--- a/LICENSE-HEADER.txt
+++ b/LICENSE-HEADER.txt
@@ -1,16 +1,14 @@
-/*******************************************************************************
- * Copyright (C) 2019-${year} Lembas Modding Team
- * 
- * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Lesser General Public License as published by
- * the Free Software Foundation, either version 3 of the License, or
- * (at your option) any later version.
- * 
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Lesser General Public License for more details.
- * 
- * You should have received a copy of the GNU Lesser General Public License
- * along with this program.  If not, see <http://www.gnu.org/licenses/>.
- ******************************************************************************/
+Copyright (C) 2019-${year} Lembas Modding Team
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU Lesser General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.

--- a/LICENSE-HEADER.txt
+++ b/LICENSE-HEADER.txt
@@ -1,0 +1,16 @@
+/*******************************************************************************
+ * Copyright (C) 2019-${year} Lembas Modding Team
+ * 
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ * 
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ * 
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ ******************************************************************************/

--- a/build.gradle
+++ b/build.gradle
@@ -16,14 +16,16 @@ buildscript {
     dependencies {
         classpath 'net.minecraftforge.gradle:ForgeGradle:1.2-SNAPSHOT'
         classpath "gradle.plugin.de.set.gradle:gradle-eclipse-compiler-plugin:1.4.1"
+        classpath "net.minecrell.licenser:net.minecrell.licenser.gradle.plugin:0.+"
     }
 }
 
 apply plugin: 'forge'
 apply plugin: "de.set.ecj"
+apply plugin: "net.minecrell.licenser"
 
 version = version
-group= "lembas"
+group = "lembas"
 archivesBaseName = "lembas-core"
 
 srcCompat = JavaVersion.VERSION_1_8
@@ -81,3 +83,14 @@ processResources {
         exclude 'mcmod.info'
     }
 }
+
+license {
+	header = project.file('LICENSE-HEADER.txt')
+
+	ext {
+		year = Calendar.getInstance().get(Calendar.YEAR)
+	}
+
+	include '**/*.java'
+}
+compileJava.dependsOn updateLicenses


### PR DESCRIPTION
With this system, upon each build, it will check if all the `java` files contain the correct copyright header, and if not, update/add it.